### PR TITLE
Update `react-router-dom` to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react-bootstrap": "^2.5.0",
         "react-dom": "^18.2.0",
         "react-refresh": "^0.18.0",
-        "react-router-dom": "^6.11.0",
+        "react-router-dom": "^7.0.0",
         "resolve": "1.22.12",
         "resolve-url-loader": "^5.0.0",
         "rxjs": "^7.8.1",
@@ -5888,14 +5888,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.0.tgz",
-      "integrity": "sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@restart/hooks": {
@@ -21352,33 +21344,51 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.0.tgz",
-      "integrity": "sha512-hTm6KKNpj9SDG4syIWRjCU219O0RZY8RUPobCFt9p+PlF7nnkRgMoh2DieTKvw3F3Mw6zg565HGnSv8BuoY5oQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "dependencies": {
-        "@remix-run/router": "1.6.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.0.tgz",
-      "integrity": "sha512-Q3mK1c/CYoF++J6ZINz7EZzwlgSOZK/kc7lxIA7PhtWhKju4KfF1WHqlx0kVCIFJAWztuYVpXZeljEbds8z4Og==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "dependencies": {
-        "@remix-run/router": "1.6.0",
-        "react-router": "6.11.0"
+        "react-router": "7.16.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-transition-group": {
@@ -22453,6 +22463,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -28905,11 +28920,6 @@
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
-    },
-    "@remix-run/router": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.0.tgz",
-      "integrity": "sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w=="
     },
     "@restart/hooks": {
       "version": "0.4.7",
@@ -39715,20 +39725,27 @@
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="
     },
     "react-router": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.0.tgz",
-      "integrity": "sha512-hTm6KKNpj9SDG4syIWRjCU219O0RZY8RUPobCFt9p+PlF7nnkRgMoh2DieTKvw3F3Mw6zg565HGnSv8BuoY5oQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "requires": {
-        "@remix-run/router": "1.6.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+          "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="
+        }
       }
     },
     "react-router-dom": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.0.tgz",
-      "integrity": "sha512-Q3mK1c/CYoF++J6ZINz7EZzwlgSOZK/kc7lxIA7PhtWhKju4KfF1WHqlx0kVCIFJAWztuYVpXZeljEbds8z4Og==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "requires": {
-        "@remix-run/router": "1.6.0",
-        "react-router": "6.11.0"
+        "react-router": "7.16.0"
       }
     },
     "react-transition-group": {
@@ -40512,6 +40529,11 @@
         "parseurl": "~1.3.3",
         "send": "0.19.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.2.0",
     "react-refresh": "^0.18.0",
-    "react-router-dom": "^6.11.0",
+    "react-router-dom": "^7.0.0",
     "resolve": "1.22.12",
     "resolve-url-loader": "^5.0.0",
     "rxjs": "^7.8.1",
@@ -148,7 +148,8 @@
       "!src/setupProxy.ts"
     ],
     "setupFiles": [
-      "react-app-polyfill/jsdom"
+      "react-app-polyfill/jsdom",
+      "<rootDir>/src/setupGlobals.ts"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/src/setupTests.ts"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,7 +242,7 @@ const App: React.FunctionComponent = () => {
       if (location.pathname === "/notfound" || location.pathname === "/") {
         return;
       }
-      history("/notfound");
+      void history("/notfound");
     }
   }, [location, defaultBranch, branches]);
 
@@ -265,7 +265,7 @@ const App: React.FunctionComponent = () => {
       setHasMoreLog(hasMore);
       setPaginationToken(token);
     } else {
-      history("/notfound");
+      void history("/notfound");
     }
   };
 

--- a/src/CommitLog/CommitLog.tsx
+++ b/src/CommitLog/CommitLog.tsx
@@ -120,7 +120,9 @@ const CommitLog = ({
                 <Button
                   variant="light"
                   className={"ml-3 rightBtnHover"}
-                  onClick={() => history(`/tree/${branch}:${hash as string}`)}
+                  onClick={() =>
+                    void history(`/tree/${branch}:${hash as string}`)
+                  }
                 >
                   <Code />
                 </Button>

--- a/src/ExploreLink/ExploreLink.tsx
+++ b/src/ExploreLink/ExploreLink.tsx
@@ -39,7 +39,11 @@ const ExploreLink = ({
       ? "/content/"
       : "/commits/";
   return (
-    <Link to={`${prefix}${currentRef}/${path.join("/")}`} className={className}>
+    <Link
+      to={`${prefix}${currentRef}/${path.join("/")}`}
+      className={className}
+      discover="none"
+    >
       {children}
     </Link>
   );

--- a/src/setupGlobals.ts
+++ b/src/setupGlobals.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(globalThis, { TextDecoder, TextEncoder });


### PR DESCRIPTION
Update `react-router-dom` to v7

`react-router-dom` v7 still supports React 18, so it can move independently from the React and MUI majors. The runtime app compiled without route API changes, but Jest needed a pre-import setup file because React Router now reads `TextEncoder` during module initialization and `setupFilesAfterEnv` runs too late for that.

React Router v7 also emits discovery metadata on links by default. Disable discovery in the shared `ExploreLink` wrapper so existing generated hrefs and snapshots stay focused on the actual navigation output.

React Router v7 can return promises from navigation calls. The direct redirect handlers now explicitly discard those promises with `void` so the existing type-aware ESLint rules continue to pass during production builds.